### PR TITLE
Allow spaces in between the comment tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VSCode Inline SQL Highlight
 
-VSCode extension that highlights the SQL queries from your code if you have a ```/*sql*/``` comment in front of the string that contains SQL.
+VSCode extension that highlights the SQL queries from your code if you have a ```/* sql */``` comment in front of the string that contains SQL.
 
 ## Before
 <img src="before.png">

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-inline-sql-highlight",
 	"displayName": "Inline SQL Highlight",
 	"description": "Highlights the SQL queries from your code",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"publisher": "derefs",
 	"license": "MIT",
 	"repository": {

--- a/syntaxes/inline-sql.json
+++ b/syntaxes/inline-sql.json
@@ -5,7 +5,7 @@
     {
       "name": "sqlQueries",
       "contentName": "meta.embedded.block.sql",
-      "begin": "..sql.. ?((`))",
+      "begin": ".. ?sql ?.. ?((`))",
       "beginCaptures": {
         "1": {
           "name": "entity.name.function.tagged-template.js"


### PR DESCRIPTION
JSDoc-like comments have spaces in between the comment tags and the text. This is in line with the [MDM lexical grammar - Block comments documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#block_comments) resource and recognized by formatters such as the [prettier embed plugin](https://github.com/Sec-ant/prettier-plugin-embed)

This change allows comments such as `/*sql*/` and `/* sql */` to be recognized by the highlighter as well as all the combinations in between (`/*sql */` and `/* sql*/`)

<img width="218" height="112" alt="Screenshot from 2025-12-23 10-43-30" src="https://github.com/user-attachments/assets/ee60cda5-d2ef-487b-8072-bc5fcaf08bd8" />
